### PR TITLE
Add issue templates

### DIFF
--- a/ISSUE_TEMPLATE/bug-report.md
+++ b/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Tell us about a problem you are experiencing
+---
+
+**What steps did you take and what happened:**
+[A clear and concise description of what the bug is.]
+
+
+**What did you expect to happen:**
+
+
+**Anything else you would like to add:**
+[Miscellaneous information that will assist in solving the issue.]
+
+
+**Environment:**
+
+- Software version:
+- Kubernetes version: (use `kubectl version`):
+- Kubernetes installer & version:
+- Cloud provider or hardware configuration:
+- OS (e.g. from `/etc/os-release`):

--- a/ISSUE_TEMPLATE/feature-enhancement-request.md
+++ b/ISSUE_TEMPLATE/feature-enhancement-request.md
@@ -1,0 +1,7 @@
+---
+name: Feature enhancement request
+about: Suggest an idea for this project
+---
+
+**Please describe the problem you have**
+[A clear, concise, description of the problem you are facing. What is the _problem_ that feature X would solve for you?]


### PR DESCRIPTION
This PR adds default issue templates to be used across the org.

Signed-off-by: Jonas Rosland <jrosland@vmware.com>